### PR TITLE
test now fails if user isn't logged in can create

### DIFF
--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe NotesController, type: :controller do
   describe 'post create' do
     it "can't create a note if you're not logged in" do
       post :create, note: {content: 'hush', visible_to: ''}
+      note = Note.last
+      last_note_content = note.content if note
+      assert last_note_content != 'hush'
       assert_redirected_to '/'
     end
     it "can create a note if you're logged in" do


### PR DESCRIPTION
The test was passing even though my code was allowing a non-logged in user to create a note and save it to the database.  The user_id column was nil, but the note was created nonetheless.  The added assertion makes sure that the content of the last note of the database doesn't match the content of the note that was submitted to the post request to the NotesController's :create action.